### PR TITLE
Feature: Task Editing

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
           <i class="fas fa-plus mr-2"></i>ADD
         </button>
       </form>
+      <div class="text-xs text-gray-400 mt-2 italic">Try clicking Task label for editing mode</div>
     </section>
     
     <!-- Task List -->


### PR DESCRIPTION
### Changes
- Added ability to click on task labels to enter edit mode
- Implemented inline editing with save and cancel options
- Added keyboard support (Enter to save, Escape to cancel)
- Prevented editing of completed tasks
- Added visual cues and instructions for better UX
- Added new state management for tracking which task is being edited

### How to Test
1. Add a task to the list
2. Click on the task label (not the checkbox) to enter edit mode
3. Edit the task text
4. Either:
   - Press Enter or click the green check mark to save changes
   - Press Escape or click the red X to cancel
5. Verify that completed tasks cannot be edited
6. Test with multiple tasks and different filters